### PR TITLE
chore(php): Remove useles 'user' directive in FPM config

### DIFF
--- a/php/config/php-fpm.conf
+++ b/php/config/php-fpm.conf
@@ -8,7 +8,6 @@ log_limit = 8192
 [app]
 
 listen = 9000
-user = php
 clear_env = no
 
 access.log = /proc/self/fd/2


### PR DESCRIPTION
This directive is ignored when FPM is not running as root.
