### PR TITLE
refactor(php): Enhance FPM's access log format

### DIFF
--- a/php/config/php-fpm.conf
+++ b/php/config/php-fpm.conf
@@ -2,7 +2,7 @@
 
 daemonize = no
 
-error_log = /proc/self/fd/2
+error_log = "/proc/self/fd/2"
 log_limit = 8192
 
 [app]
@@ -10,7 +10,8 @@ log_limit = 8192
 listen = 9000
 clear_env = no
 
-access.log = /proc/self/fd/2
+access.log = "/proc/self/fd/2"
+access.format = "(HIT) %R - [%{%Y-%m-%dT%T%z}t] \"%m %r%Q%q\" %s - %{seconds}ds %{mega}MMB"
 catch_workers_output = yes
 decorate_workers_output = no
 

--- a/php/config/php.ini
+++ b/php/config/php.ini
@@ -4,7 +4,6 @@ max_input_time = 60
 output_buffering = 4096
 default_mimetype = "text/plain"
 
-error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 display_errors = Off
 display_startup_errors = Off
 log_errors = On


### PR DESCRIPTION
Also, do not enforce any error reporting level, as it's impossible to
choose a generic enough value, so it's better to let applications set
the best value for themselves.
